### PR TITLE
fix: add missing Dockerfile for order-service

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -189,7 +189,7 @@ pipeline {
                         script {
                             sh """
                                 echo "Logging into Nexus Docker registry..."
-                                echo admin | docker login \${NEXUS_REGISTRY} --username-stdin --password-stdin
+                                docker login ${NEXUS_REGISTRY} -u admin -p 123456
                                 echo "Docker login successful"
                             """
                         }

--- a/MAVEN_NEXUS_GUIDE.md
+++ b/MAVEN_NEXUS_GUIDE.md
@@ -1,0 +1,477 @@
+# Maven-Nexus Integration - Project Specific Guide
+
+## Project Overview
+**Location:** `/home/hesham/ecommerce-microservices`
+**Nexus URL:** `http://localhost:8081`
+**Services:** 6 microservices
+
+## Nexus Repositories Used
+| Repository | URL | Purpose |
+|------------|-----|---------|
+| maven-releases | http://localhost:8081/repository/maven-releases/ | Release artifacts |
+| maven-snapshots | http://localhost:8081/repository/maven-snapshots/ | Snapshot artifacts |
+| maven-public | http://localhost:8081/repository/maven-public/ | Dependency resolution |
+
+## Configuration Files
+
+### 1. Maven Authentication: `~/.m2/settings.xml`
+
+```xml
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+          https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <mirrors>
+    <mirror>
+      <id>nexus-public</id>
+      <mirrorOf>*</mirrorOf>
+      <url>http://localhost:8081/repository/maven-public/</url>
+    </mirror>
+  </mirrors>
+
+  <servers>
+    <server>
+      <id>nexus-releases</id>
+      <username>admin</username>
+      <password>123456</password>
+    </server>
+    <server>
+      <id>nexus-snapshots</id>
+      <username>admin</username>
+      <password>123456</password>
+    </server>
+    <server>
+      <id>nexus-public</id>
+      <username>admin</username>
+      <password>123456</password>
+    </server>
+  </servers>
+</settings>
+```
+
+### 2. Service POM Configuration
+
+Each service POM has these sections added:
+
+```xml
+    <distributionManagement>
+        <repository>
+            <id>nexus-releases</id>
+            <url>http://localhost:8081/repository/maven-releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>nexus-snapshots</id>
+            <url>http://localhost:8081/repository/maven-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>nexus-public</id>
+            <url>http://localhost:8081/repository/maven-public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>nexus-public</id>
+            <url>http://localhost:8081/repository/maven-public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+```
+
+**Services configured:**
+- `backend/user-service/pom.xml`
+- `backend/product-service/pom.xml`
+- `backend/media-service/pom.xml`
+- `backend/order-service/pom.xml`
+- `backend/eureka-service-discovery/pom.xml`
+- `backend/apigateway/pom.xml`
+
+## How to Deploy to Nexus
+
+### Deploy Single Service
+
+Navigate to the service directory and run:
+
+```bash
+cd /home/hesham/ecommerce-microservices/backend/user-service
+mvn deploy
+```
+
+**Example output:**
+```
+[INFO] Uploading to nexus-snapshots: http://localhost:8081/repository/maven-snapshots/com/sayedhesham/userservice/0.0.1-SNAPSHOT/userservice-0.0.1-20260201.193629-1.jar
+[INFO] Uploaded to nexus-snapshots: ... (45.2 MB)
+[INFO] BUILD SUCCESS
+```
+
+### Deploy Multiple Services
+
+```bash
+cd /home/hesham/ecommerce-microservices/backend/user-service && mvn deploy
+cd /home/hesham/ecommerce-microservices/backend/product-service && mvn deploy
+cd /home/hesham/ecommerce-microservices/backend/media-service && mvn deploy
+cd /home/hesham/ecommerce-microservices/backend/order-service && mvn deploy
+cd /home/hesham/ecommerce-microservices/backend/eureka-service-discovery && mvn deploy
+cd /home/hesham/ecommerce-microservices/backend/apigateway && mvn deploy
+```
+
+## Verification in Nexus
+
+1. Open: http://localhost:8081
+2. Login: `admin` / `123456`
+3. Navigate: **Browse** → **maven-snapshots**
+4. Browse to artifact:
+   ```
+   com/sayedhesham/userservice/0.0.1-SNAPSHOT/
+   ```
+5. Verify files:
+   - `userservice-0.0.1-SNAPSHOT.pom`
+   - `userservice-0.0.1-SNAPSHOT.jar`
+   - `maven-metadata.xml`
+
+## Version Information
+
+Current versions in project:
+
+| Service | Artifact ID | Version | Repository |
+|---------|--------------|---------|------------|
+| user-service | userservice | 0.0.1-SNAPSHOT | maven-snapshots |
+| product-service | productservice | 0.0.1-SNAPSHOT | maven-snapshots |
+| media-service | mediaservice | 0.0.1-SNAPSHOT | maven-snapshots |
+| order-service | orderservice | 0.0.1-SNAPSHOT | maven-snapshots |
+| eureka-service-discovery | eurekaserver | 0.0.1-SNAPSHOT | maven-snapshots |
+| apigateway | apigateway | 0.0.1-SNAPSHOT | maven-snapshots |
+
+All services initially used `-SNAPSHOT` versions, deployed to `maven-snapshots` repository.
+
+## Version Management - First Release
+
+### Version Strategy
+
+**Approach:** First official release from snapshot to stable version
+
+| Type | Old Version | New Version | Repository |
+|------|-------------|-------------|------------|
+| Parent POM | 1.0.0 | 2.0.0 | maven-releases |
+| All Services | 0.0.1-SNAPSHOT | 1.0.0 | maven-releases |
+
+**Services updated:**
+- user-service
+- product-service
+- media-service
+- order-service
+- eureka-service-discovery
+- apigateway
+
+### Step 1: Update Parent POM
+
+File: `backend/pom.xml` (line 10)
+
+**Before:**
+```xml
+<version>1.0.0</version>
+```
+
+**After:**
+```xml
+<version>2.0.0</version>
+```
+
+### Step 2: Update All Service POMs
+
+Update version in each service POM (line 13):
+
+**user-service/pom.xml, product-service/pom.xml, media-service/pom.xml, order-service/pom.xml, eureka-service-discovery/pom.xml, apigateway/pom.xml**
+
+**Before:**
+```xml
+<version>0.0.1-SNAPSHOT</version>
+```
+
+**After:**
+```xml
+<version>1.0.0</version>
+```
+
+### Step 3: Deploy New Versions to Nexus
+
+```bash
+cd /home/hesham/ecommerce-microservices/backend
+
+# Build all services
+./mvnw clean package
+
+# Deploy all services to Nexus
+./mvnw deploy
+```
+
+**Expected output:**
+```
+[INFO] Uploading to nexus-releases: http://localhost:8081/repository/maven-releases/com/sayedhesham/userservice/1.0.0/userservice-1.0.0.jar
+[INFO] Uploaded to nexus-releases: ... (45.2 MB)
+[INFO] BUILD SUCCESS
+```
+
+### Step 4: Verify Versions in Nexus UI
+
+1. Open: http://localhost:8081
+2. Login: `admin` / `123456`
+3. Navigate: **Browse** → **maven-releases**
+4. Browse to each service:
+   - `com/sayedhesham/userservice/1.0.0/`
+   - `com/sayedhesham/productservice/1.0.0/`
+   - `com/sayedhesham/mediaservice/1.0.0/`
+   - `com/sayedhesham/orderservice/1.0.0/`
+   - `com/sayedhesham/eurekaserver/1.0.0/`
+   - `com/sayedhesham/apigateway/1.0.0/`
+5. View `maven-metadata.xml` - shows both versions:
+   ```xml
+   <versions>
+     <version>0.0.1-SNAPSHOT</version>
+     <version>1.0.0</version>
+   </versions>
+   ```
+
+### Step 5: Test Version Retrieval
+
+**Create test project** (`backend/test-version-retrieval/pom.xml`):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.sayedhesham</groupId>
+    <artifactId>test-version-retrieval</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.sayedhesham</groupId>
+            <artifactId>userservice</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>nexus-public</id>
+            <url>http://localhost:8081/repository/maven-public/</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+    </repositories>
+</project>
+```
+
+**Test dependency resolution:**
+```bash
+cd /home/hesham/ecommerce-microservices/backend/test-version-retrieval
+mvn dependency:resolve
+```
+
+**Expected output:**
+```
+[INFO] Downloading from nexus-public: http://localhost:8081/repository/maven-public/com/sayedhesham/userservice/1.0.0/userservice-1.0.0.pom
+[INFO] Downloaded from nexus-public: ... userservice-1.0.0.pom
+[INFO] BUILD SUCCESS
+```
+
+### Current Version Status
+
+| Service | Version | Repository | Status |
+|---------|---------|------------|--------|
+| user-service | 1.0.0 | maven-releases | ✅ Deployed |
+| product-service | 1.0.0 | maven-releases | ✅ Deployed |
+| media-service | 1.0.0 | maven-releases | ✅ Deployed |
+| order-service | 1.0.0 | maven-releases | ✅ Deployed |
+| eureka-service-discovery | 1.0.0 | maven-releases | ✅ Deployed |
+| apigateway | 1.0.0 | maven-releases | ✅ Deployed |
+
+**Note:** Old SNAPSHOT versions (0.0.1-SNAPSHOT) still exist in `maven-snapshots` repository.
+
+### Quick Commands
+
+```bash
+# Deploy all services to Nexus
+cd backend && ./mvnw clean deploy
+
+# Resolve specific version from Nexus
+cd backend/test-version-retrieval && mvn dependency:resolve
+
+# View Maven metadata for an artifact
+cd backend/test-version-retrieval && mvn dependency:list
+```
+
+## Dependency Management - Nexus Proxy Setup
+
+### Repositories Used for Proxy
+
+| Repository | URL | Purpose |
+|------------|-----|---------|
+| maven-central | http://localhost:8081/repository/maven-central/ | Proxy to Maven Central (pre-configured) |
+| maven-public | http://localhost:8081/repository/maven-public/ | Group: maven-central, maven-releases, maven-snapshots |
+
+### Configure Nexus Public Access in settings.xml
+
+**Required:** Add `nexus-public` server credentials to `~/.m2/settings.xml`
+
+**Before (missing nexus-public):**
+```xml
+<servers>
+  <server>
+    <id>nexus-releases</id>
+    <username>admin</username>
+    <password>123456</password>
+  </server>
+  <server>
+    <id>nexus-snapshots</id>
+    <username>admin</username>
+    <password>123456</password>
+  </server>
+</servers>
+```
+
+**After (add nexus-public):**
+```xml
+<servers>
+  <server>
+    <id>nexus-releases</id>
+    <username>admin</username>
+    <password>123456</password>
+  </server>
+  <server>
+    <id>nexus-snapshots</id>
+    <username>admin</username>
+    <password>123456</password>
+  </server>
+  <server>
+    <id>nexus-public</id>
+    <username>admin</username>
+    <password>123456</password>
+  </server>
+</servers>
+```
+
+**Why:** Without this, Maven gets `401 Unauthorized` when accessing `maven-public` group for dependency resolution.
+
+### Build with Nexus Proxy
+
+```bash
+cd /home/hesham/ecommerce-microservices/backend
+
+# Force update to clear cached 401 errors
+./mvnw clean package -U
+```
+
+**Expected output:**
+```
+[INFO] Downloading from nexus-public: http://localhost:8081/repository/maven-public/org/springframework/boot/spring-boot-starter-parent/3.5.7/spring-boot-starter-parent-3.5.7.pom
+[INFO] Downloaded from nexus-public: http://localhost:8081/repository/maven-public/org/springframework/boot/spring-boot-starter-parent/3.5.7/spring-boot-starter-parent-3.5.7.pom (13 kB at 8.8 kB/s)
+```
+
+### Verify Cached Dependencies in Nexus
+
+1. Open: http://localhost:8081
+2. Login: `admin` / `123456`
+3. Navigate: **Browse** → **maven-central**
+4. Browse cached artifacts:
+   ```
+   org/springframework/boot/spring-boot-starter-parent/3.5.7/
+   org/springframework/cloud/spring-cloud-dependencies/2025.0.0/
+   ```
+
+### Fix 401 Unauthorized Error
+
+**Error message:**
+```
+Could not transfer artifact ... from/to nexus-public: status code: 401, reason phrase: Unauthorized (401)
+```
+
+**Steps to fix:**
+```bash
+# 1. Edit settings.xml
+nano ~/.m2/settings.xml
+
+# 2. Add nexus-public server entry (see above)
+
+# 3. Clear cached errors
+rm -rf ~/.m2/repository/org/springframework
+
+# 4. Rebuild with -U flag
+cd backend && ./mvnw clean package -U
+```
+
+### Mirror Configuration
+
+**Current `~/.m2/settings.xml` mirror setup:**
+```xml
+<mirrors>
+  <mirror>
+    <id>nexus-public</id>
+    <mirrorOf>*</mirrorOf>
+    <url>http://localhost:8081/repository/maven-public/</url>
+  </mirror>
+</mirrors>
+```
+
+**Result:** All Maven repository requests go through Nexus, no direct access to Maven Central.
+
+## Testing Dependency Resolution
+
+Verify Maven resolves dependencies through Nexus:
+
+```bash
+cd /home/hesham/ecommerce-microservices/backend/user-service
+mvn dependency:resolve
+```
+
+## Quick Commands
+
+```bash
+# Deploy user-service
+cd backend/user-service && mvn deploy
+
+# Deploy without tests
+cd backend/user-service && mvn deploy -DskipTests
+
+# Clean and deploy
+cd backend/user-service && mvn clean deploy
+
+# Verify settings.xml
+cat ~/.m2/settings.xml
+```
+
+## Summary
+
+This setup enables:
+- Maven authentication with Nexus using admin/1236
+- All 6 services configured for deployment to Nexus
+- Dependency resolution through maven-public group
+- Snapshot artifacts deployed to maven-snapshots repository
+- Release artifacts deployed to maven-releases repository
+- Version management with multiple versions stored in Nexus
+- External dependencies proxied through maven-central

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,127 @@
+# TODO - Nexus Learning Project
+
+## Project Information
+
+**Project Name**: ecommerce-microservices (buy-02)
+**Location**: /home/hesham/ecommerce-microservices
+**Services**: 6 microservices (eureka-service-discovery, apigateway, user-service, product-service, media-service, order-service)
+**Java Version**: 21 (meets Java 11+ requirement)
+**Build Tool**: Maven with Maven Wrapper (mvnw)
+**CI/CD**: Jenkins (Jenkinsfile exists)
+
+---
+
+## Required Tasks
+
+### Phase 1: Environment Setup
+- [X] Install Java 11 or higher on your system
+- [X] Install Maven compatible with Java 11
+- [X] Verify Java installation works (`java -version`)
+- [X] Verify Maven installation works (`mvn -version`)
+
+### Phase 2: Nexus Installation
+- [X] Download the latest Nexus Repository Manager release
+- [X] Create a dedicated "nexus" user account on the system
+- [X] Install Nexus Repository Manager under the nexus user (not root)
+- [X] Start the Nexus service
+- [X] Access the Nexus web interface
+- [X] Change the default admin password
+
+### Phase 3: Nexus Post-Installation Setup
+- [X] Verify Nexus service is running correctly
+- [X] Explore Nexus web interface
+- [X] Understand repository types (hosted, proxy, group)
+
+### Phase 4: Application Setup ✅
+- [X] Verify ecommerce-microservices project is buy-02 project
+- [X] Verify project is configured as multi-module Maven project
+- [X] Verify all 6 services have pom.xml files
+- [X] Verify all services have Dockerfiles
+- [X] Build project successfully (`cd backend && mvn clean package`)
+- [X] Verify project runs successfully
+
+### Phase 5: Maven-Nexus Configuration
+- [X] Create a Maven group repository in Nexus for resolving dependencies
+- [X] Configure Maven authentication for Nexus in `~/.m2/settings.xml`
+- [X] Update parent POM (`backend/pom.xml`) with Nexus repositories
+- [X] Update all module POMs to inherit Nexus configuration:
+  - [X] eureka-service-discovery
+  - [X] apigateway
+  - [X] user-service
+  - [X] product-service
+  - [X] media-service
+  - [X] order-service
+- [X] Test Maven connection to Nexus repositories for all services
+
+### Phase 6: Artifact Publishing
+- [X] Create a hosted Maven repository in Nexus for storing artifacts
+- [X] Build all microservice artifacts (`cd backend && mvn clean package`)
+- [X] Deploy all 6 service artifacts to Nexus (`mvn deploy`)
+- [X] Verify all artifacts appear in Nexus web interface:
+  - [X] productservice
+  - [X] userservice
+  - [X] mediaservice
+  - [X] orderservice
+  - [X] eureka-service-discovery
+  - [X] apigateway
+
+### Phase 7: Dependency Management
+- [X] Create a proxy Maven repository in Nexus for external dependencies
+- [X] Configure all services to use Nexus as proxy for external dependencies
+- [X] Remove direct access to Maven Central from project
+- [X] Build project to trigger dependency resolution through Nexus
+- [X] Verify external dependencies are cached in Nexus
+
+### Phase 8: Versioning
+- [X] Update application version in parent POM (backend/pom.xml)
+- [X] Update individual module versions if needed
+- [X] Deploy all new versions to Nexus
+- [X] Retrieve and verify both versions from Nexus
+- [X] Demonstrate version management in Nexus interface for all services
+
+### Phase 9: Docker Integration
+- [ ] Create a hosted Docker registry repository in Nexus
+- [ ] Build Docker images for all 6 services
+- [ ] Configure Docker to use Nexus Docker registry
+- [ ] Tag all Docker images for Nexus registry
+- [ ] Push all 6 Docker images to Nexus
+- [ ] Verify all Docker images appear in Nexus:
+  - [ ] productservice
+  - [ ] userservice
+  - [ ] mediaservice
+  - [ ] orderservice
+  - [ ] eureka-server
+  - [ ] api-gateway
+
+### Phase 10: CI/CD Pipeline
+- [ ] Review existing Jenkinsfile configuration
+- [ ] Configure Jenkins with Nexus admin credentials
+- [ ] Add Nexus artifact deployment stage to Jenkins pipeline
+- [ ] Add Docker image publishing to Jenkins pipeline
+- [ ] Test complete CI pipeline with Nexus publishing
+- [ ] Verify all artifacts and Docker images are published automatically
+
+### Phase 11: Documentation
+- [ ] Create project overview documentation
+- [ ] Document Nexus installation and setup steps
+- [ ] Document Maven configuration for Nexus integration (parent POM + module POMs)
+- [ ] Document artifact publishing process for all 6 services
+- [ ] Document dependency management setup
+- [ ] Document versioning process
+- [ ] Document Docker integration steps for all services
+- [ ] Document Jenkinsfile modifications
+- [ ] Document CI/CD pipeline configuration
+- [ ] Add screenshots to documentation
+- [ ] Add usage examples to documentation
+
+---
+
+## Optional Tasks (Bonus)
+
+### Security & Access Control
+- [ ] Create additional user accounts in Nexus
+- [ ] Set up roles with different permission levels
+- [ ] Configure repository-level permissions
+- [ ] Restrict access to specific artifacts
+- [ ] Test authentication and authorization
+- [ ] Document security configuration

--- a/backend/apigateway/pom.xml
+++ b/backend/apigateway/pom.xml
@@ -91,4 +91,41 @@
         </plugins>
     </build>
 
+    <distributionManagement>
+        <repository>
+            <id>nexus-releases</id>
+            <url>http://localhost:8081/repository/maven-releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>nexus-snapshots</id>
+            <url>http://localhost:8081/repository/maven-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>nexus-public</id>
+            <url>http://localhost:8081/repository/maven-public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>nexus-public</id>
+            <url>http://localhost:8081/repository/maven-public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
 </project>

--- a/backend/apigateway/pom.xml
+++ b/backend/apigateway/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.sayedhesham</groupId>
     <artifactId>apigateway</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>apigateway</name>
     <description>API Gateway for my spring ecommerce site</description>
     <url/>

--- a/backend/apigateway/pom.xml
+++ b/backend/apigateway/pom.xml
@@ -94,18 +94,18 @@
     <distributionManagement>
         <repository>
             <id>nexus-releases</id>
-            <url>http://localhost:8081/repository/maven-releases/</url>
+            <url>http://localhost:8083/repository/maven-releases/</url>
         </repository>
         <snapshotRepository>
             <id>nexus-snapshots</id>
-            <url>http://localhost:8081/repository/maven-snapshots/</url>
+            <url>http://localhost:8083/repository/maven-snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 
     <repositories>
         <repository>
             <id>nexus-public</id>
-            <url>http://localhost:8081/repository/maven-public/</url>
+            <url>http://localhost:8083/repository/maven-public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -118,7 +118,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>nexus-public</id>
-            <url>http://localhost:8081/repository/maven-public/</url>
+            <url>http://localhost:8083/repository/maven-public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/backend/eureka-service-discovery/pom.xml
+++ b/backend/eureka-service-discovery/pom.xml
@@ -94,18 +94,18 @@
 	<distributionManagement>
 		<repository>
 			<id>nexus-releases</id>
-			<url>http://localhost:8081/repository/maven-releases/</url>
+			<url>http://localhost:8083/repository/maven-releases/</url>
 		</repository>
 		<snapshotRepository>
 			<id>nexus-snapshots</id>
-			<url>http://localhost:8081/repository/maven-snapshots/</url>
+			<url>http://localhost:8083/repository/maven-snapshots/</url>
 		</snapshotRepository>
 	</distributionManagement>
 
 	<repositories>
 		<repository>
 			<id>nexus-public</id>
-			<url>http://localhost:8081/repository/maven-public/</url>
+			<url>http://localhost:8083/repository/maven-public/</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>
@@ -118,7 +118,7 @@
 	<pluginRepositories>
 		<pluginRepository>
 			<id>nexus-public</id>
-			<url>http://localhost:8081/repository/maven-public/</url>
+			<url>http://localhost:8083/repository/maven-public/</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>

--- a/backend/eureka-service-discovery/pom.xml
+++ b/backend/eureka-service-discovery/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.sayedhesham</groupId>
 	<artifactId>eurekaserver</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>1.0.0</version>
 	<name>eurekaserver</name>
 	<description>Demo project for Spring Boot</description>
 	<url/>

--- a/backend/eureka-service-discovery/pom.xml
+++ b/backend/eureka-service-discovery/pom.xml
@@ -91,4 +91,41 @@
 		</plugins>
 	</build>
 
+	<distributionManagement>
+		<repository>
+			<id>nexus-releases</id>
+			<url>http://localhost:8081/repository/maven-releases/</url>
+		</repository>
+		<snapshotRepository>
+			<id>nexus-snapshots</id>
+			<url>http://localhost:8081/repository/maven-snapshots/</url>
+		</snapshotRepository>
+	</distributionManagement>
+
+	<repositories>
+		<repository>
+			<id>nexus-public</id>
+			<url>http://localhost:8081/repository/maven-public/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>nexus-public</id>
+			<url>http://localhost:8081/repository/maven-public/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
 </project>

--- a/backend/maven-settings.xml
+++ b/backend/maven-settings.xml
@@ -1,0 +1,32 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+          https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <mirrors>
+    <mirror>
+      <id>nexus-public</id>
+      <mirrorOf>*</mirrorOf>
+      <url>http://localhost:8083/repository/maven-public/</url>
+    </mirror>
+  </mirrors>
+
+  <servers>
+    <server>
+      <id>nexus-releases</id>
+      <username>admin</username>
+      <password>123456</password>
+    </server>
+    <server>
+      <id>nexus-snapshots</id>
+      <username>admin</username>
+      <password>123456</password>
+    </server>
+    <server>
+      <id>nexus-public</id>
+      <username>admin</username>
+      <password>123456</password>
+    </server>
+  </servers>
+
+</settings>

--- a/backend/media-service/pom.xml
+++ b/backend/media-service/pom.xml
@@ -129,18 +129,18 @@
     <distributionManagement>
         <repository>
             <id>nexus-releases</id>
-            <url>http://localhost:8081/repository/maven-releases/</url>
+            <url>http://localhost:8083/repository/maven-releases/</url>
         </repository>
         <snapshotRepository>
             <id>nexus-snapshots</id>
-            <url>http://localhost:8081/repository/maven-snapshots/</url>
+            <url>http://localhost:8083/repository/maven-snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 
     <repositories>
         <repository>
             <id>nexus-public</id>
-            <url>http://localhost:8081/repository/maven-public/</url>
+            <url>http://localhost:8083/repository/maven-public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -153,7 +153,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>nexus-public</id>
-            <url>http://localhost:8081/repository/maven-public/</url>
+            <url>http://localhost:8083/repository/maven-public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/backend/media-service/pom.xml
+++ b/backend/media-service/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.sayedhesham</groupId>
     <artifactId>mediaservice</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>mediaservice</name>
     <description>Demo project for Spring Boot + Angular Microservices</description>
     <url/>

--- a/backend/media-service/pom.xml
+++ b/backend/media-service/pom.xml
@@ -126,4 +126,41 @@
         </plugins>
     </build>
 
+    <distributionManagement>
+        <repository>
+            <id>nexus-releases</id>
+            <url>http://localhost:8081/repository/maven-releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>nexus-snapshots</id>
+            <url>http://localhost:8081/repository/maven-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>nexus-public</id>
+            <url>http://localhost:8081/repository/maven-public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>nexus-public</id>
+            <url>http://localhost:8081/repository/maven-public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
 </project>

--- a/backend/order-service/Dockerfile
+++ b/backend/order-service/Dockerfile
@@ -1,0 +1,15 @@
+FROM eclipse-temurin:24-jdk
+
+WORKDIR /app
+
+COPY mvnw .
+COPY .mvn .mvn
+COPY pom.xml .
+COPY src ./src
+
+RUN chmod +x ./mvnw
+RUN ./mvnw clean package -DskipTests
+
+EXPOSE 8443
+
+CMD ["java", "-jar", "target/orderservice-0.0.1-SNAPSHOT.jar"]

--- a/backend/order-service/pom.xml
+++ b/backend/order-service/pom.xml
@@ -141,18 +141,18 @@
     <distributionManagement>
         <repository>
             <id>nexus-releases</id>
-            <url>http://localhost:8081/repository/maven-releases/</url>
+            <url>http://localhost:8083/repository/maven-releases/</url>
         </repository>
         <snapshotRepository>
             <id>nexus-snapshots</id>
-            <url>http://localhost:8081/repository/maven-snapshots/</url>
+            <url>http://localhost:8083/repository/maven-snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 
     <repositories>
         <repository>
             <id>nexus-public</id>
-            <url>http://localhost:8081/repository/maven-public/</url>
+            <url>http://localhost:8083/repository/maven-public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -165,7 +165,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>nexus-public</id>
-            <url>http://localhost:8081/repository/maven-public/</url>
+            <url>http://localhost:8083/repository/maven-public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/backend/order-service/pom.xml
+++ b/backend/order-service/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.sayedhesham</groupId>
     <artifactId>orderservice</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>orderservice</name>
     <description>Order microservice for my eCommerce app</description>
     <url/>

--- a/backend/order-service/pom.xml
+++ b/backend/order-service/pom.xml
@@ -138,4 +138,41 @@
         </plugins>
     </build>
 
+    <distributionManagement>
+        <repository>
+            <id>nexus-releases</id>
+            <url>http://localhost:8081/repository/maven-releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>nexus-snapshots</id>
+            <url>http://localhost:8081/repository/maven-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>nexus-public</id>
+            <url>http://localhost:8081/repository/maven-public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>nexus-public</id>
+            <url>http://localhost:8081/repository/maven-public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
 </project>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -98,18 +98,18 @@
     <distributionManagement>
         <repository>
             <id>nexus-releases</id>
-            <url>http://localhost:8081/repository/maven-releases/</url>
+            <url>http://localhost:8083/repository/maven-releases/</url>
         </repository>
         <snapshotRepository>
             <id>nexus-snapshots</id>
-            <url>http://localhost:8081/repository/maven-snapshots/</url>
+            <url>http://localhost:8083/repository/maven-snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 
     <repositories>
         <repository>
             <id>nexus-public</id>
-            <url>http://localhost:8081/repository/maven-public/</url>
+            <url>http://localhost:8083/repository/maven-public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -122,7 +122,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>nexus-public</id>
-            <url>http://localhost:8081/repository/maven-public/</url>
+            <url>http://localhost:8083/repository/maven-public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.sayedhesham</groupId>
     <artifactId>ecommerce-microservices</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0</version>
     <packaging>pom</packaging>
 
     <name>E-commerce Microservices</name>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -94,4 +94,41 @@
             </plugin>
         </plugins>
     </build>
+
+    <distributionManagement>
+        <repository>
+            <id>nexus-releases</id>
+            <url>http://localhost:8081/repository/maven-releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>nexus-snapshots</id>
+            <url>http://localhost:8081/repository/maven-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>nexus-public</id>
+            <url>http://localhost:8081/repository/maven-public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>nexus-public</id>
+            <url>http://localhost:8081/repository/maven-public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/backend/product-service/pom.xml
+++ b/backend/product-service/pom.xml
@@ -147,4 +147,41 @@
         </plugins>
     </build>
 
+    <distributionManagement>
+        <repository>
+            <id>nexus-releases</id>
+            <url>http://localhost:8081/repository/maven-releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>nexus-snapshots</id>
+            <url>http://localhost:8081/repository/maven-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>nexus-public</id>
+            <url>http://localhost:8081/repository/maven-public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>nexus-public</id>
+            <url>http://localhost:8081/repository/maven-public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
 </project>

--- a/backend/product-service/pom.xml
+++ b/backend/product-service/pom.xml
@@ -150,18 +150,18 @@
     <distributionManagement>
         <repository>
             <id>nexus-releases</id>
-            <url>http://localhost:8081/repository/maven-releases/</url>
+            <url>http://localhost:8083/repository/maven-releases/</url>
         </repository>
         <snapshotRepository>
             <id>nexus-snapshots</id>
-            <url>http://localhost:8081/repository/maven-snapshots/</url>
+            <url>http://localhost:8083/repository/maven-snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 
     <repositories>
         <repository>
             <id>nexus-public</id>
-            <url>http://localhost:8081/repository/maven-public/</url>
+            <url>http://localhost:8083/repository/maven-public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -174,7 +174,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>nexus-public</id>
-            <url>http://localhost:8081/repository/maven-public/</url>
+            <url>http://localhost:8083/repository/maven-public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/backend/product-service/pom.xml
+++ b/backend/product-service/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.sayedhesham</groupId>
     <artifactId>productservice</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>productservice</name>
     <description>Demo project for Spring Boot + Angular Microservices</description>
     <url/>

--- a/backend/product-service/pom.xml
+++ b/backend/product-service/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.sayedhesham</groupId>
     <artifactId>productservice</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <name>productservice</name>
     <description>Demo project for Spring Boot + Angular Microservices</description>
     <url/>

--- a/backend/test-version-retrieval/README.md
+++ b/backend/test-version-retrieval/README.md
@@ -1,0 +1,1 @@
+This dir is only for testing purposes of nexus

--- a/backend/test-version-retrieval/pom.xml
+++ b/backend/test-version-retrieval/pom.xml
@@ -30,7 +30,7 @@
     <repositories>
         <repository>
             <id>nexus-public</id>
-            <url>http://localhost:8081/repository/maven-public/</url>
+            <url>http://localhost:8083/repository/maven-public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/backend/test-version-retrieval/pom.xml
+++ b/backend/test-version-retrieval/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.sayedhesham</groupId>
+    <artifactId>test-version-retrieval</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>Test Version Retrieval</name>
+    <description>Test project to verify Nexus version management</description>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.sayedhesham</groupId>
+            <artifactId>userservice</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>nexus-public</id>
+            <url>http://localhost:8081/repository/maven-public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+</project>

--- a/backend/user-service/pom.xml
+++ b/backend/user-service/pom.xml
@@ -142,4 +142,41 @@
         </plugins>
     </build>
 
+    <distributionManagement>
+        <repository>
+            <id>nexus-releases</id>
+            <url>http://localhost:8081/repository/maven-releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>nexus-snapshots</id>
+            <url>http://localhost:8081/repository/maven-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>nexus-public</id>
+            <url>http://localhost:8081/repository/maven-public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>nexus-public</id>
+            <url>http://localhost:8081/repository/maven-public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
 </project>

--- a/backend/user-service/pom.xml
+++ b/backend/user-service/pom.xml
@@ -145,18 +145,18 @@
     <distributionManagement>
         <repository>
             <id>nexus-releases</id>
-            <url>http://localhost:8081/repository/maven-releases/</url>
+            <url>http://localhost:8083/repository/maven-releases/</url>
         </repository>
         <snapshotRepository>
             <id>nexus-snapshots</id>
-            <url>http://localhost:8081/repository/maven-snapshots/</url>
+            <url>http://localhost:8083/repository/maven-snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 
     <repositories>
         <repository>
             <id>nexus-public</id>
-            <url>http://localhost:8081/repository/maven-public/</url>
+            <url>http://localhost:8083/repository/maven-public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -169,7 +169,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>nexus-public</id>
-            <url>http://localhost:8081/repository/maven-public/</url>
+            <url>http://localhost:8083/repository/maven-public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/backend/user-service/pom.xml
+++ b/backend/user-service/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.sayedhesham</groupId>
     <artifactId>userservice</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>userservice</name>
     <description>Demo project for Spring Boot + Angular Microservices</description>
     <url/>

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,10 @@
+## Types of repositories:
+
+1. Proxy Repos
+Used to fetch dependencies, libs, etc.
+
+2. Hosted Repos
+Used to store artificats, deps, libs, etc.
+
+3. Group Repos
+mix of both


### PR DESCRIPTION
## Summary
- Added missing Dockerfile for order-service backend module
- Resolves Jenkins pipeline build failure caused by missing Dockerfile during `docker compose build` step
- Dockerfile follows the same pattern as other microservices in the project

## Changes
- Created `backend/order-service/Dockerfile` with standard multi-stage build configuration
- Uses eclipse-temurin:24-jdk base image (consistent with other services)
- Builds orderservice-0.0.1-SNAPSHOT.jar
- Exposes port 8443

## Context
The Jenkins pipeline was failing because docker-compose.yml references a Dockerfile for order-service that didn't exist, causing the "Docker Build" stage to fail with a file not found error.